### PR TITLE
Fix build and enable opaque-pointers support in tests.

### DIFF
--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -214,13 +214,13 @@ public:
 
     // Dispatch the function call as appropriate, based on the types that the
     // function may be called with.
-    if constexpr (is_invocable<FnType, IRBuilder<> &, Value *, Type *>::value)
+    if constexpr (std::is_invocable<FnType, IRBuilder<> &, Value *, Type *>::value)
       replaceArg(Index, Func(Builder, V, T));
-    else if constexpr (is_invocable<FnType, IRBuilder<> &, Value *>::value)
+    else if constexpr (std::is_invocable<FnType, IRBuilder<> &, Value *>::value)
       replaceArg(Index, Func(Builder, V));
-    else if constexpr (is_invocable<FnType, Value *, Type *>::value)
+    else if constexpr (std::is_invocable<FnType, Value *, Type *>::value)
       replaceArg(Index, Func(V, T));
-    else if constexpr (is_invocable<FnType, Value *>::value)
+    else if constexpr (std::is_invocable<FnType, Value *>::value)
       replaceArg(Index, Func(V));
     else {
       // We need a helper value that is always false, but is dependent on the

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc 
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpImageWrite.cl
+++ b/test/transcoding/OpImageWrite.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -O1 -triple spir-unknown-unknown -cl-std=CL2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -O1 -triple spir-unknown-unknown -cl-std=CL2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc 
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpenCL/atomic_cmpxchg.cl
+++ b/test/transcoding/OpenCL/atomic_cmpxchg.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc 
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/atomic_legacy.cl
+++ b/test/transcoding/OpenCL/atomic_legacy.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc 
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_media_block_io.cl
+++ b/test/transcoding/SPV_INTEL_media_block_io.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc 
 // RUN: llvm-spirv --spirv-ext=+SPV_INTEL_media_block_io %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: spirv-val %t.spv

--- a/test/transcoding/atomic_explicit_arguments.cl
+++ b/test/transcoding/atomic_explicit_arguments.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc 
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.spv -r --spirv-target-env=CL2.0 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc 
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv


### PR DESCRIPTION
Patches in `mutator-decomposed` branch enabled atomic tests in addition to the tests in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1612.